### PR TITLE
Update Android minSdkVersion and targetSdkVersion.

### DIFF
--- a/AndroidPushPlugin/app/build.gradle
+++ b/AndroidPushPlugin/app/build.gradle
@@ -5,8 +5,8 @@ android {
     buildToolsVersion "22.0.1"
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 17
+        minSdkVersion 16
+        targetSdkVersion 25
     }
 
     buildTypes {

--- a/UnityPushPlugin/Assets/Plugins/Android/AndroidManifest.xml
+++ b/UnityPushPlugin/Assets/Plugins/Android/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.kii.unity.sample.push"
     android:versionCode="1"
     android:versionName="1.0" >
-    <uses-sdk android:targetSdkVersion="18" android:minSdkVersion="9" />
+    <uses-sdk android:targetSdkVersion="25" android:minSdkVersion="16" />
     
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
Unity 5.6.0f3 requires minSdkVersion 16 or above.